### PR TITLE
Fixes Nepal Phone number length

### DIFF
--- a/assets/mobileNumberLengthByCountry.json
+++ b/assets/mobileNumberLengthByCountry.json
@@ -481,9 +481,9 @@
   },
   {
     "country": "Nepal",
-    "phoneNumberLengthByCountry_phLengthMax": 9,
-    "phoneNumberLengthByCountry_phLengthMin": 8,
-    "phoneNumberLengthByCountry_phLength": "8 to 9",
+    "phoneNumberLengthByCountry_phLengthMax": 10,
+    "phoneNumberLengthByCountry_phLengthMin": 9,
+    "phoneNumberLengthByCountry_phLength": "9 to 10",
     "phoneNumberLengthByCountry_CountryCode": 977,
     "phoneNumberLengthByCountry_phLength_InternationalPrefix": 0,
     "phoneNumberLengthByCountry_phLength_NationalPrefix": 0,

--- a/src/assets/countryData.json
+++ b/src/assets/countryData.json
@@ -481,9 +481,9 @@
   },
   {
     "country": "Nepal",
-    "phoneNumberLengthByCountry_phLengthMax": 9,
-    "phoneNumberLengthByCountry_phLengthMin": 8,
-    "phoneNumberLengthByCountry_phLength": "8 to 9",
+    "phoneNumberLengthByCountry_phLengthMax": 10,
+    "phoneNumberLengthByCountry_phLengthMin": 9,
+    "phoneNumberLengthByCountry_phLength": "9 to 10",
     "phoneNumberLengthByCountry_CountryCode": 977,
     "phoneNumberLengthByCountry_phLength_InternationalPrefix": 0,
     "phoneNumberLengthByCountry_phLength_NationalPrefix": 0,


### PR DESCRIPTION
I'm currently using this library in my project and encountered an issue when validating Nepal (+977) mobile numbers. The current configuration allows a maximum length of 9 digits, but Nepalese mobile numbers are actually 10 digits long. After checking the country config, I found that the length constraints were "8 to 9". This PR updates the values to: "9 to 10".
According to Google's libphonenumber, Nepal mobile numbers follow a 10-digit format. This change will ensure accurate validation for Nepalese users and allow me (and others) to continue using this library confidently in production. Happy to discuss or adjust if needed!